### PR TITLE
Update the HELICS GitHub repo url

### DIFF
--- a/helics/meta.yaml
+++ b/helics/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/GMLC-TDC/HELICS-src/archive/v2.0.0.tar.gz
+  url: https://github.com/GMLC-TDC/HELICS/archive/v2.0.0.tar.gz
   sha256: {{ checksum }}
 
 build:
@@ -39,14 +39,14 @@ test:
     - helics
 
 about:
-  home: https://github.com/GMLC-TDC/HELICS-src
+  home: https://github.com/GMLC-TDC/HELICS
   license: BSD
   license_file: LICENSE
   license_family: BSD
   summary: 'Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS) framework'
   description: 'Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS) framework'
-  doc_url: http://gmlc-tdc.github.io/HELICS-src/index.html
-  dev_url: https://github.com/GMLC-TDC/HELICS-src
+  doc_url: https://helics.readthedocs.io/en/latest/
+  dev_url: https://github.com/GMLC-TDC/HELICS
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Updates the HELICS GitHub repo url after the June 19, 2019 change from HELICS-src